### PR TITLE
Replace winapi dep with lawrencium

### DIFF
--- a/gl_context/Cargo.toml
+++ b/gl_context/Cargo.toml
@@ -20,7 +20,7 @@ objc = "0.2.7"
 objc = "0.2.7"
 
 [target.'cfg(target_os="windows")'.dependencies]
-winapi = { version = "0.3.8", features = ["winuser", "libloaderapi", "windowsx"] }
+lawrencium = "1"
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 wasm-bindgen = "0.2.*"

--- a/gl_context/src/windows/mod.rs
+++ b/gl_context/src/windows/mod.rs
@@ -263,7 +263,7 @@ pub fn new_opengl_context(
         dummy_pfd.nVersion = 1;
         dummy_pfd.dwFlags =
             PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
-        dummy_pfd.iPixelType = PFD_TYPE_RGBA;
+        dummy_pfd.iPixelType = PFD_TYPE_RGBA as u8;
         dummy_pfd.cColorBits = 32;
         dummy_pfd.cAlphaBits = 8;
         dummy_pfd.cDepthBits = 24;
@@ -305,11 +305,11 @@ pub fn new_opengl_context(
         // https://www.khronos.org/registry/OpenGL/extensions/ARB/WGL_ARB_pixel_format.txt
         let pixel_attributes = vec![
             WGL_DRAW_TO_WINDOW_ARB,
-            TRUE,
+            TRUE as i32,
             WGL_SUPPORT_OPENGL_ARB,
-            TRUE,
+            TRUE as i32,
             WGL_DOUBLE_BUFFER_ARB,
-            TRUE,
+            TRUE as i32,
             WGL_PIXEL_TYPE_ARB,
             WGL_TYPE_RGBA_ARB,
             WGL_ACCELERATION_ARB,
@@ -327,7 +327,7 @@ pub fn new_opengl_context(
             WGL_SAMPLES_ARB,
             msaa_samples as i32,
             WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB,
-            if srgb { TRUE } else { FALSE },
+            if srgb { TRUE as i32 } else { FALSE as i32 },
             0,
         ];
 


### PR DESCRIPTION
[`lawrencium`](https://github.com/Lokathor/lawrencium) is a crate that provides
> Bindings to a limited subset of the Windows API.

Not only is it much smaller than pulling in `winapi` as is done now, it's also zlib licensed, so I think it would be a good idea to replace `winapi` with it. Currently waiting on https://github.com/Lokathor/lawrencium/pull/4.