### PR TITLE
Use Git for lawrencium dep

### DIFF
--- a/gl_context/Cargo.toml
+++ b/gl_context/Cargo.toml
@@ -20,7 +20,7 @@ objc = "0.2.7"
 objc = "0.2.7"
 
 [target.'cfg(target_os="windows")'.dependencies]
-lawrencium = {git = "https://github.com/Lokathor/lawrencium"}
+lawrencium = {git = "https://github.com/Lokathor/lawrencium", rev = "4079f8a"}
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 wasm-bindgen = "0.2.*"

--- a/gl_context/Cargo.toml
+++ b/gl_context/Cargo.toml
@@ -20,7 +20,7 @@ objc = "0.2.7"
 objc = "0.2.7"
 
 [target.'cfg(target_os="windows")'.dependencies]
-lawrencium = "1"
+lawrencium = {git = "https://github.com/Lokathor/lawrencium"}
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 wasm-bindgen = "0.2.*"


### PR DESCRIPTION
Continuation of #46. The needed changes upstream haven't been published on crates.io yet, so we need to source the dep from GitHub until further developments arise. I was about to make this change in the previous PR but it was merged 😅

Warning, untested! Should work, but not a hundred percent confident on whether I specified the commit hash correctly. If it builds, should mean its fine.