### PR TITLE
Refactor double click events, implement them for web

### DIFF
--- a/kapp_platform_common/src/events.rs
+++ b/kapp_platform_common/src/events.rs
@@ -104,7 +104,6 @@ pub enum Event {
     /// Occurs when pressing a mouse button twice in quick succession.
     /// This event occurs after two click and release pairs in quick succession.
     /// For the standard behaviour per platform, use `DoubleClick` event instead.
-    /// Unimplemented on Windows
     DoubleClickUp {
         x: f64,
         y: f64,

--- a/kapp_platform_common/src/events.rs
+++ b/kapp_platform_common/src/events.rs
@@ -83,10 +83,18 @@ pub enum Event {
         timestamp: Duration,
     },
     /// Occurs when pressing a mouse button twice in quick succession.
+    /// On Windows, this event occurs after the second click but before its release.
+    /// On MacOS and Web, this event occurs after two click and release pairs in quick succession.
+    DoubleClick {
+        x: f64,
+        y: f64,
+        button: PointerButton,
+        timestamp: Duration,
+    },
+    /// Occurs when pressing a mouse button twice in quick succession.
     /// This event occurs after the second click but before its release.
-    /// This event should be used to make double clicks feel more responsive,
-    /// but `MouseButtonDoubleClickUp` more closely matches the behavior of browser double click.
-    /// Unimplemented on Web
+    /// This event should be used to make double clicks feel more responsive.
+    /// For the standard behaviour per platform, use `DoubleClick` event instead.
     DoubleClickDown {
         x: f64,
         y: f64,
@@ -95,8 +103,9 @@ pub enum Event {
     },
     /// Occurs when pressing a mouse button twice in quick succession.
     /// This event occurs after two click and release pairs in quick succession.
-    /// Unimplemented on Web and Windows
-    MouseButtonDoubleClickUp {
+    /// For the standard behaviour per platform, use `DoubleClick` event instead.
+    /// Unimplemented on Windows
+    DoubleClickUp {
         x: f64,
         y: f64,
         button: PointerButton,

--- a/kapp_platforms/src/macos/events_mac.rs
+++ b/kapp_platforms/src/macos/events_mac.rs
@@ -378,7 +378,13 @@ extern "C" fn mouse_up(this: &Object, _sel: Sel, event: *mut Object) {
     });
     let click_count: c_int = unsafe { msg(event, Sels::clickCount, ()) };
     if click_count == 2 {
-        self::submit_event(Event::MouseButtonDoubleClickUp {
+        self::submit_event(Event::DoubleClickUp {
+            x,
+            y,
+            button: PointerButton::Primary,
+            timestamp: get_timestamp(event),
+        });
+        self::submit_event(Event::DoubleClick {
             x,
             y,
             button: PointerButton::Primary,
@@ -420,7 +426,13 @@ extern "C" fn right_mouse_up(this: &Object, _sel: Sel, event: *mut Object) {
     });
     let click_count: c_int = unsafe { msg(event, Sels::clickCount, ()) };
     if click_count == 2 {
-        self::submit_event(Event::MouseButtonDoubleClickUp {
+        self::submit_event(Event::DoubleClickUp {
+            x,
+            y,
+            button: PointerButton::Secondary,
+            timestamp: get_timestamp(event),
+        });
+        self::submit_event(Event::DoubleClick {
             x,
             y,
             button: PointerButton::Secondary,
@@ -478,7 +490,13 @@ extern "C" fn other_mouse_up(this: &Object, _sel: Sel, event: *mut Object) {
     });
     let click_count: c_int = unsafe { msg(event, Sels::clickCount, ()) };
     if click_count == 2 {
-        self::submit_event(Event::MouseButtonDoubleClickUp {
+        self::submit_event(Event::DoubleClickUp {
+            x,
+            y,
+            button,
+            timestamp: get_timestamp(event),
+        });
+        self::submit_event(Event::DoubleClick {
             x,
             y,
             button,

--- a/kapp_platforms/src/web/application_web.rs
+++ b/kapp_platforms/src/web/application_web.rs
@@ -82,7 +82,7 @@ impl PlatformApplicationTrait for PlatformApplication {
         unsafe {
             CURRENT_CURSOR = Some(cursor_name.into());
         }
-        style.set_property("cursor", cursor_name);
+        style.set_property("cursor", cursor_name).ok();
     }
     fn hide_cursor(&mut self) {
         let style = web_sys::window()
@@ -93,7 +93,7 @@ impl PlatformApplicationTrait for PlatformApplication {
             .unwrap()
             .unchecked_into::<HtmlElement>()
             .style();
-        style.set_property("cursor", "none");
+        style.set_property("cursor", "none").ok();
     }
     fn show_cursor(&mut self) {
         let style = web_sys::window()
@@ -106,7 +106,7 @@ impl PlatformApplicationTrait for PlatformApplication {
             .style();
         style.set_property("cursor", unsafe {
             CURRENT_CURSOR.as_deref().unwrap_or("auto")
-        });
+        }).ok();
     }
 
     fn raw_window_handle(&self, _window_id: WindowId) -> RawWindowHandle {
@@ -119,11 +119,11 @@ impl PlatformApplicationTrait for PlatformApplication {
 
     fn set_text_input_rectangle(
         &mut self,
-        window_id: WindowId,
-        x: f64,
-        y: f64,
-        width: f64,
-        height: f64,
+        _window_id: WindowId,
+        _x: f64,
+        _y: f64,
+        _width: f64,
+        _height: f64,
     ) {
         // Perhaps a hidden text input field could be moved to make IME input appear in the right place.
     }

--- a/kapp_platforms/src/web/event_loop_web.rs
+++ b/kapp_platforms/src/web/event_loop_web.rs
@@ -138,18 +138,26 @@ where
         // Double click (up) event
         let dblclick = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
             let (x, y) = (event.client_x().into(), event.client_y().into());
-            send_event(Event::MouseButtonDoubleClickUp {
+            let button = match event.button() {
+                0 => PointerButton::Primary,
+                1 => PointerButton::Auxillary,
+                2 => PointerButton::Secondary,
+                3 => PointerButton::Extra1,
+                4 => PointerButton::Extra2,
+                _ => PointerButton::Unknown,
+            };
+            let timestamp = Duration::from_secs_f64(event.time_stamp() * 1000.0);
+            send_event(Event::DoubleClickUp {
                 x,
                 y,
-                button: match event.button() {
-                    0 => PointerButton::Primary,
-                    1 => PointerButton::Auxillary,
-                    2 => PointerButton::Secondary,
-                    3 => PointerButton::Extra1,
-                    4 => PointerButton::Extra2,
-                    _ => PointerButton::Unknown,
-                },
-                timestamp: Duration::from_secs_f64(event.time_stamp() * 1000.0),
+                button,
+                timestamp,
+            });
+            send_event(Event::DoubleClick {
+                x,
+                y,
+                button,
+                timestamp,
             });
         }) as Box<dyn FnMut(web_sys::MouseEvent)>);
         canvas.set_ondblclick(Some(dblclick.as_ref().unchecked_ref()));

--- a/kapp_platforms/src/web/event_loop_web.rs
+++ b/kapp_platforms/src/web/event_loop_web.rs
@@ -113,6 +113,48 @@ where
         canvas.set_onpointerdown(Some(pointer_down.as_ref().unchecked_ref()));
         pointer_down.forget();
 
+        // Mouse down event for DoubleClickDown
+        let mouse_down = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
+            if event.detail() == 2 {
+                let (x, y) = (event.client_x().into(), event.client_y().into());
+                send_event(Event::DoubleClickDown {
+                    x,
+                    y,
+                    button: match event.button() {
+                        0 => PointerButton::Primary,
+                        1 => PointerButton::Auxillary,
+                        2 => PointerButton::Secondary,
+                        3 => PointerButton::Extra1,
+                        4 => PointerButton::Extra2,
+                        _ => PointerButton::Unknown,
+                    },
+                    timestamp: Duration::from_secs_f64(event.time_stamp() * 1000.0),
+                });
+            }
+        }) as Box<dyn FnMut(web_sys::MouseEvent)>);
+        canvas.set_onmousedown(Some(mouse_down.as_ref().unchecked_ref()));
+        mouse_down.forget();
+
+        // Double click (up) event
+        let dblclick = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
+            let (x, y) = (event.client_x().into(), event.client_y().into());
+            send_event(Event::MouseButtonDoubleClickUp {
+                x,
+                y,
+                button: match event.button() {
+                    0 => PointerButton::Primary,
+                    1 => PointerButton::Auxillary,
+                    2 => PointerButton::Secondary,
+                    3 => PointerButton::Extra1,
+                    4 => PointerButton::Extra2,
+                    _ => PointerButton::Unknown,
+                },
+                timestamp: Duration::from_secs_f64(event.time_stamp() * 1000.0),
+            });
+        }) as Box<dyn FnMut(web_sys::MouseEvent)>);
+        canvas.set_ondblclick(Some(dblclick.as_ref().unchecked_ref()));
+        dblclick.forget();
+
         // Pointer up event
         let pointer_up = Closure::wrap(Box::new(move |event: web_sys::PointerEvent| {
             let (x, y) = get_pointer_position(&event);


### PR DESCRIPTION
Fixes https://github.com/kettle11/kapp/issues/21 EXCEPT implementing `DoubleClickUp` for Windows. 
The `detail` property is always 0 for `pointerdown` (https://github.com/w3c/pointerevents/issues/98), so I had to add `mousedown` just for the double clicks.