### PR TITLE
Add some flags

### DIFF
--- a/gl_context/src/common.rs
+++ b/gl_context/src/common.rs
@@ -49,7 +49,7 @@ pub trait GLContextTrait {
     fn set_vsync(&mut self, vsync: VSync) -> Result<(), std::io::Error>;
     fn get_vsync(&self) -> VSync;
 
-    /// Asssigns a window to draw to
+    /// Assigns a window to draw to
     fn set_window(
         &mut self,
         window: Option<&impl raw_window_handle::HasRawWindowHandle>,
@@ -90,7 +90,7 @@ impl GLContextBuilder {
         self
     }
 
-    /// Sets if the window should use the sRGB color space.
+    /// Sets if the context should use the sRGB color space.
     /// This has no effect on Web.
     pub fn srgb(&mut self, srgb: bool) -> &mut Self {
         self.gl_attributes.srgb = srgb;

--- a/gl_context/src/common.rs
+++ b/gl_context/src/common.rs
@@ -5,6 +5,7 @@ pub struct GLContextAttributes {
     pub alpha_bits: u8,
     pub depth_bits: u8,
     pub stencil_bits: u8,
+    pub srgb: bool,
     /// msaa_samples hould be a multiple of 2
     pub msaa_samples: u8,
     /// WebGL version is only relevant for web.
@@ -72,6 +73,27 @@ pub struct GLContextBuilder {
 impl GLContextBuilder {
     pub fn samples(&mut self, samples: u8) -> &mut Self {
         self.gl_attributes.msaa_samples = samples;
+        self
+    }
+
+    /// Sets the major version.
+    /// This is presently only relevant on Windows.
+    pub fn version_major(&mut self, version: u8) -> &mut Self {
+        self.gl_attributes.version_major = version;
+        self
+    }
+
+    /// Sets the minor version.
+    /// This is presently only relevant on Windows.
+    pub fn version_minor(&mut self, version: u8) -> &mut Self {
+        self.gl_attributes.version_minor = version;
+        self
+    }
+
+    /// Sets if the window should use the sRGB color space.
+    /// This has no effect on Web.
+    pub fn srgb(&mut self, srgb: bool) -> &mut Self {
+        self.gl_attributes.srgb = srgb;
         self
     }
 

--- a/gl_context/src/ios.rs
+++ b/gl_context/src/ios.rs
@@ -25,6 +25,7 @@ impl GLContext {
                 alpha_bits: 8,
                 depth_bits: 24,
                 stencil_bits: 8,
+                srgb: true,
                 webgl_version: WebGLVersion::None,
             },
         }

--- a/gl_context/src/macos.rs
+++ b/gl_context/src/macos.rs
@@ -73,6 +73,7 @@ impl GLContext {
                 alpha_bits: 8,
                 depth_bits: 24,
                 stencil_bits: 8,
+                srgb: true,
                 webgl_version: WebGLVersion::None,
                 high_resolution_framebuffer: false,
             },

--- a/gl_context/src/web.rs
+++ b/gl_context/src/web.rs
@@ -77,6 +77,7 @@ impl GLContext {
                 alpha_bits: 8,
                 depth_bits: 24,
                 stencil_bits: 8,
+                srgb: true,
                 webgl_version: WebGLVersion::One,
                 high_resolution_framebuffer: false,
             },

--- a/gl_context/src/windows/mod.rs
+++ b/gl_context/src/windows/mod.rs
@@ -30,6 +30,7 @@ impl GLContext {
                 alpha_bits: 8,
                 depth_bits: 24,
                 stencil_bits: 8,
+                srgb: true,
                 webgl_version: WebGLVersion::None,
                 high_resolution_framebuffer: false,
             },
@@ -199,7 +200,7 @@ impl GLContextBuilder {
             self.gl_attributes.depth_bits,
             self.gl_attributes.stencil_bits,
             self.gl_attributes.msaa_samples,
-            false,
+            self.gl_attributes.srgb,
         )
         .unwrap())
     }

--- a/gl_context/src/windows/mod.rs
+++ b/gl_context/src/windows/mod.rs
@@ -200,6 +200,8 @@ impl GLContextBuilder {
             self.gl_attributes.depth_bits,
             self.gl_attributes.stencil_bits,
             self.gl_attributes.msaa_samples,
+            self.gl_attributes.version_major,
+            self.gl_attributes.version_minor,
             self.gl_attributes.srgb,
         )
         .unwrap())
@@ -217,6 +219,8 @@ pub fn new_opengl_context(
     depth_bits: u8,
     stencil_bits: u8,
     msaa_samples: u8,
+    version_major: u8,
+    version_minor: u8,
     srgb: bool,
 ) -> Result<GLContext, Error> {
     // This function performs the following steps:
@@ -360,8 +364,8 @@ pub fn new_opengl_context(
 
         // Finally we can create the OpenGL context!
         // Need to allow for choosing major and minor version.
-        let major_version_minimum = 4;
-        let minor_version_minimum = 5;
+        let major_version_minimum = version_major as i32;
+        let minor_version_minimum = version_minor as i32;
         let context_attributes = [
             WGL_CONTEXT_MAJOR_VERSION_ARB,
             major_version_minimum,


### PR DESCRIPTION
Fix #28 for Windows. Things work a bit differently on Mac AFAICT (your choice of versions are more limited) and I had no idea how to implement it there, so that part's incomplete.

Also partially addresses #56. This adds an srgb flag to `GlContextAttributes` then uses it for context creation on Windows.

Everything seems to build? At least on Windows? But to be quite frank I'm not sure if I implemented everything correctly 😅 One area of confusion is that at least with my test project (Windows, OpenGL) even if I disable the srgb flag I still get srgb conversions so long as I run `glEnable(GL_FRAMEBUFFER_SRGB)`. I'm *pretty* sure this is just my machine giving me a pixel format that supports srgb, even though I didn't ask for it, and not a mess-up on my part.

Might or might not want to flesh things out a bit more before merge, but hopefully this is a good starting point.