### PR TITLE
Implement maximum size flag for Windows

### DIFF
--- a/kapp_platform_common/src/window_parameters.rs
+++ b/kapp_platform_common/src/window_parameters.rs
@@ -3,6 +3,7 @@ pub struct WindowParameters {
     pub position: Option<(u32, u32)>,
     pub size: Option<(u32, u32)>,
     pub minimum_size: Option<(u32, u32)>,
+    pub maximum_size: Option<(u32, u32)>,
     pub resizable: bool,
     /// Only does anything on MacOS
     pub without_titlebar: bool,

--- a/kapp_platforms/src/windows/application_windows.rs
+++ b/kapp_platforms/src/windows/application_windows.rs
@@ -220,7 +220,7 @@ impl PlatformApplicationTrait for PlatformApplication {
                         (rect.right - rect.left, rect.bottom - rect.top)
                     });
 
-            let (minimum_width, minimum_height) = window_parameters.minimum_size.unwrap_or((0, 0));
+            let (minimum_width, minimum_height) = window_parameters.minimum_size.unwrap_or((GetSystemMetrics(SM_CXMINTRACK) as u32, GetSystemMetrics(SM_CYMINTRACK) as u32));
             let (maximum_width, maximum_height) = window_parameters.maximum_size.unwrap_or((GetSystemMetrics(SM_CXMAXTRACK) as u32, GetSystemMetrics(SM_CYMAXTRACK) as u32));
             let window_data = Box::new(WindowData {
                 minimum_width,

--- a/kapp_platforms/src/windows/application_windows.rs
+++ b/kapp_platforms/src/windows/application_windows.rs
@@ -17,6 +17,8 @@ pub struct PlatformApplication {
 pub(crate) struct WindowData {
     pub minimum_width: u32,
     pub minimum_height: u32,
+    pub maximum_width: u32,
+    pub maximum_height: u32,
 }
 
 impl PlatformApplicationTrait for PlatformApplication {
@@ -219,9 +221,12 @@ impl PlatformApplicationTrait for PlatformApplication {
                     });
 
             let (minimum_width, minimum_height) = window_parameters.minimum_size.unwrap_or((0, 0));
+            let (maximum_width, maximum_height) = window_parameters.maximum_size.unwrap_or((GetSystemMetrics(SM_CXMAXTRACK) as u32, GetSystemMetrics(SM_CYMAXTRACK) as u32));
             let window_data = Box::new(WindowData {
                 minimum_width,
                 minimum_height,
+                maximum_width,
+                maximum_height,
             });
 
             let data = Box::leak(window_data) as *mut WindowData as *mut std::ffi::c_void;

--- a/kapp_platforms/src/windows/event_loop_windows.rs
+++ b/kapp_platforms/src/windows/event_loop_windows.rs
@@ -329,6 +329,8 @@ pub unsafe extern "system" fn window_callback(
                 let min_max_info = l_param as *mut MINMAXINFO;
                 (*min_max_info).ptMinTrackSize.x = (*window_data).minimum_width as i32;
                 (*min_max_info).ptMinTrackSize.y = (*window_data).minimum_height as i32;
+                (*min_max_info).ptMaxTrackSize.x = (*window_data).maximum_width as i32;
+                (*min_max_info).ptMaxTrackSize.y = (*window_data).maximum_height as i32;
             }
         }
         WM_NCDESTROY => {

--- a/kapp_platforms/src/windows/external_windows.rs
+++ b/kapp_platforms/src/windows/external_windows.rs
@@ -346,6 +346,8 @@ pub const PM_REMOVE: UINT = 0x0001;
 
 pub const SM_CXSCREEN: c_int = 0;
 pub const SM_CYSCREEN: c_int = 1;
+pub const SM_CXMAXTRACK: c_int = 59;
+pub const SM_CYMAXTRACK: c_int = 60;
 
 pub const SIZE_RESTORED: WPARAM = 0;
 pub const SIZE_MINIMIZED: WPARAM = 1;

--- a/kapp_platforms/src/windows/external_windows.rs
+++ b/kapp_platforms/src/windows/external_windows.rs
@@ -346,6 +346,8 @@ pub const PM_REMOVE: UINT = 0x0001;
 
 pub const SM_CXSCREEN: c_int = 0;
 pub const SM_CYSCREEN: c_int = 1;
+pub const SM_CXMINTRACK: c_int = 34;
+pub const SM_CYMINTRACK: c_int = 35;
 pub const SM_CXMAXTRACK: c_int = 59;
 pub const SM_CYMAXTRACK: c_int = 60;
 

--- a/src/window_builder.rs
+++ b/src/window_builder.rs
@@ -14,6 +14,7 @@ impl<'a> WindowBuilder<'a> {
                 position: None,
                 size: Some((500, 500)),
                 minimum_size: None,
+                maximum_size: None,
                 resizable: true,
                 without_titlebar: false,
                 title: "Untitled".to_string(),
@@ -48,6 +49,12 @@ impl<'a> WindowBuilder<'a> {
     /// Sets the minimum size of the window's content area (excluding the titlebar and borders)
     pub fn minimum_size(&mut self, width: u32, height: u32) -> &mut Self {
         self.window_parameters.minimum_size = Some((width, height));
+        self
+    }
+
+    /// Sets the maximum size of the window's content area (excluding the titlebar and borders)
+    pub fn maximum_size(&mut self, width: u32, height: u32) -> &mut Self {
+        self.window_parameters.maximum_size = Some((width, height));
         self
     }
 


### PR DESCRIPTION
Implement #22 for Windows.

One thing to note, unrelated to the actual issue. The default minimum size on Windows is `(GetSystemMetrics(SM_CXMINTRACK), GetSystemMetrics(SM_CYMINTRACK))`. Not sure what value that is, but maybe we should use that instead of `(0, 0)` in the `unwrap_or` call for `minimum_size`?